### PR TITLE
CP-12967: Add support for reading the low memory mode flag exposed by tapdisk3 in xsiostat

### DIFF
--- a/xsiostat.c
+++ b/xsiostat.c
@@ -94,9 +94,9 @@ main_loop(xsis_vbds_t *vbds){
         // Print header
         if (!header){
             printf("----------------------------------------------------" \
-                   "----------------\n");
+                   "----------------------------------\n");
             printf("  DOM   VBD         r/s        w/s    rMB/s    wMB/s" \
-                   " rAvgQs wAvgQs\n");
+                   " rAvgQs wAvgQs   Low_Mem_Mode\n");
             header = 1;
         }
 
@@ -124,6 +124,7 @@ main_loop(xsis_vbds_t *vbds){
         printf("%6.2f",
                ((float)(vbd->tdstat.wtu_0-vbd->tdstat.wtu_1))/
                (now_diff*1000000));
+        printf("%6d",vbd->tdstat.low_mem_mode);
 
         // Break line
         printf("\n");

--- a/xsiostat.h
+++ b/xsiostat.h
@@ -20,6 +20,7 @@
 
 // Required headers
 #include <stdint.h>
+#include <stdbool.h>
 #include <unistd.h>
 #include <sys/queue.h>
 
@@ -50,6 +51,7 @@ typedef struct _xsis_tdstat_t {
     uint64_t            wtu_1;          // write ticks in usec last time
     uint32_t            infrd;          // read requests inflight
     uint32_t            infwr;          // write requests inflight
+    bool                low_mem_mode;   // tapdisk low memory mode
 } xsis_tdstat_t;
 
 // VBD general entry
@@ -96,6 +98,8 @@ void
 flts_free(xsis_flts_t *);
 
 // From blktap3.h:
+#define BT3_LOW_MEMORY_MODE 0x0000000000000001
+
 struct blkback_stats {
     unsigned long long  st_ds_req;
     unsigned long long  st_f_req;
@@ -110,5 +114,6 @@ struct blkback_stats {
     unsigned long long  st_wr_sect;
     long long           st_wr_sum_usecs;
     long long           st_wr_max_usecs;
+    unsigned long long  flags;
 } __attribute__ ((aligned (8)));
 

--- a/xsiostat_vbd.c
+++ b/xsiostat_vbd.c
@@ -117,6 +117,7 @@ vbd_update(xsis_vbd_t *vbd){
                         ((struct blkback_stats *)(vbd->shmmap))->st_rd_cnt;
     vbd->tdstat.infwr = ((struct blkback_stats *)(vbd->shmmap))->st_wr_req -
                         ((struct blkback_stats *)(vbd->shmmap))->st_wr_cnt;
+    vbd->tdstat.low_mem_mode = ((struct blkback_stats *)(vbd->shmmap))->flags & BT3_LOW_MEMORY_MODE;
 
 out:
     // Return


### PR DESCRIPTION
This commit adds support in xsiostat CLI to read the low memory mode
flag exposed by tapdisk3 via /dev/shm.

Signed-off-by: Koushik Chakravarty <koushik.chakravarty@citrix.com>